### PR TITLE
Official Gradle Wrapper Validation Action

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,10 @@
+name: "Validate Gradle Wrapper"
+on: [push, pull_request]
+
+jobs:
+  validation:
+    name: "Validation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
To protect against malicious gradle-wrapper.jar binaries, I have added an action that verifies its checksum.

See: https://github.com/gradle/wrapper-validation-action