### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 5


### PR DESCRIPTION
I saw that some dependencies in the GitHub action workflows were out of date. Since GitHub is always migrating to newer Node runtimes it is important to keep GitHub action dependencies up to date so they won't become incompatible all of a sudden.