### PR TITLE
Auto-scroll main menu to second item only on round screens

### DIFF
--- a/app/src/main/java/net/devemperor/wristassist/activities/MainActivity.java
+++ b/app/src/main/java/net/devemperor/wristassist/activities/MainActivity.java
@@ -132,9 +132,11 @@ public class MainActivity extends AppCompatActivity {
 
         mainWrv.requestFocus();
         mainWrv.postDelayed(() -> {
-            View view = mainWrv.getChildAt(0);
-            if (view == null) return;
-            mainWrv.scrollBy(0, view.getHeight());
+            if (getResources().getConfiguration().isScreenRound()) {
+                View view = mainWrv.getChildAt(0);
+                if (view == null) return;
+                mainWrv.scrollBy(0, view.getHeight());
+            }
         }, 100);
     }
 


### PR DESCRIPTION
Previously, the main menu would auto-scroll to the second item on both round and square screens, causing the first item to be hidden on square screens.
![image](https://github.com/user-attachments/assets/1414a4d7-970e-4f3f-8d5b-aeff0250c88e)
This fixes the problem by only scrolling on round screens.